### PR TITLE
chore: update Deepgram SDK to v1.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deepgram-starters/live-go-starter
 go 1.20
 
 require (
-	github.com/deepgram/deepgram-go-sdk v1.6.1
+	github.com/deepgram/deepgram-go-sdk v1.6.2
 	github.com/gorilla/websocket v1.5.1
 	github.com/joho/godotenv v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/deepgram/deepgram-go-sdk v1.6.1 h1:OX4vR694nafehKGhs0ZyBFLS8pQJJkQ3TTW6DLzg92E=
-github.com/deepgram/deepgram-go-sdk v1.6.1/go.mod h1:il+6HLmvxa47EG12LG6VwzaHcyI8Lo+yfBsOcDq3R8s=
+github.com/deepgram/deepgram-go-sdk v1.6.2 h1:kKeDC9cghQU9g4a4OFP2R0UdnFHOE6kRuTiw1l9TzYY=
+github.com/deepgram/deepgram-go-sdk v1.6.2/go.mod h1:il+6HLmvxa47EG12LG6VwzaHcyI8Lo+yfBsOcDq3R8s=
 github.com/dvonthenen/websocket v1.5.1-dyv.2 h1:OXlWJJkeHt8k4+MEI0Y8SQjY2ihHYD2z/tI7sZZfsnA=
 github.com/dvonthenen/websocket v1.5.1-dyv.2/go.mod h1:q2GbopbpFJvBP4iqVvqwwahVmvu2HnCfdqCWDoQVKMM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=


### PR DESCRIPTION
This PR updates the Deepgram SDK to version v1.6.2.