### PR TITLE
update transcription client from live to listen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/deepgram-starters/live-go-starter
 
-go 1.20
+go 1.23.0
+
+toolchain go1.24.4
 
 require (
 	github.com/deepgram/deepgram-go-sdk v1.6.2
@@ -16,7 +18,7 @@ require (
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
-	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,10 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
-golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=

--- a/main.go
+++ b/main.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"strings"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
 	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/live"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
 	"github.com/joho/godotenv"
 
 	"github.com/gorilla/websocket"
@@ -124,7 +124,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	callback := NewMyCallback(conn)
 
 	// Create a new Deepgram LiveTranscription client with config options
-	dgClient, err := client.New(ctx, apiKey, &clientOptions, &transcriptOptions, callback)
+	dgClient, err := client.NewWSUsingCallback(ctx, apiKey, &clientOptions, &transcriptOptions, callback)
 	if err != nil {
 		fmt.Println("ERROR creating LiveTranscription connection:", err)
 		return
@@ -184,8 +184,11 @@ func main() {
 		log.Fatal("Error loading .env file")
 	}
 
+	serverAddress := "0.0.0.0:8080"
+
 	client.InitWithDefault()
 	http.Handle("/", http.StripPrefix("/", http.FileServer(http.Dir("./public"))))
 	http.HandleFunc("/ws", handleWebSocket)
-	http.ListenAndServe(":8080", nil)
+	fmt.Println("Server started on ", serverAddress)
+	http.ListenAndServe(serverAddress, nil)
 }


### PR DESCRIPTION
"github.com/deepgram/deepgram-go-sdk/pkg/client/live" is deprecated and will be removed in a future release. 
Use the listen package as suggested